### PR TITLE
Add real data instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,17 @@ cp .env.example .env
 # .env 파일에서 KAKAO_API_KEY 값 수정
 ```
 
+### 2-1. 실제 데이터 다운로드
+Google Drive에 공유된 실제 데이터를 `gdown`으로 받을 수 있습니다.
+
+```bash
+pip install gdown
+gdown --folder https://drive.google.com/drive/folders/1CTZWeh_QHPRpc5qUEwwLMwVG8ctAlLpk -O data/real_data
+```
+
+다운로드가 완료되면 `data/real_data` 폴더 아래에 Shapefile 및 CSV 파일이 저장됩니다.
+웹 툴에서 파일 업로드 시 해당 폴더의 파일을 선택하면 됩니다.
+
 ### 3. 애플리케이션 실행
 ```bash
 python app.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pyproj==3.6.1
 folium==0.14.0
 geojson==3.0.1
 python-dotenv==1.0.0
+gdown==5.2.0


### PR DESCRIPTION
## Summary
- include gdown in dependencies to easily download Google Drive folders
- describe how to download the real dataset

## Testing
- `python -m py_compile app.py data_processor.py score_calculator.py`


------
https://chatgpt.com/codex/tasks/task_e_68750c3f3bf08321abdccbe013f008bb